### PR TITLE
Add GetAllJobs from the wsdl, used to receive all jobs and their respec…

### DIFF
--- a/Rcc/Job.php
+++ b/Rcc/Job.php
@@ -12,100 +12,122 @@ class Job
 {
 	public ?GridService $arbiter = null;
 	public ?LuaScript $script = null;
-	
+
 	public function __construct(public string $id = '', public int $expirationInSeconds = 20, public int $cores = 0, public int $category = 0)
 	{
-		if(empty($this->id))
-		{
+		if (empty($this->id)) {
 			// This generates a RFC 4122 compliant Version 4 UUID to be used as a default job ID.
 			// https://www.rfc-editor.org/rfc/rfc4122#section-4.4
 			// https://stackoverflow.com/a/15875555
 			$guidv4 = random_bytes(16);
 			$guidv4[6] = chr(ord($guidv4[6]) & 0x0f | 0x40); // Encode time_hi_and_version
 			$guidv4[8] = chr(ord($guidv4[8]) & 0x3f | 0x80); // Encode clock_seq_hi_and_reserved
-			
+
 			$this->id = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($guidv4), 4));
 		}
 	}
-	
+
 	public function arbiter(GridService $arbiter): Job
 	{
 		$this->arbiter = $arbiter;
 		return $this;
 	}
-	
+
 	public function script(LuaScript $script): Job
 	{
 		$this->script = $script;
 		return $this;
 	}
-	
+
 	public function open(): array
 	{
-		if(!$this->arbiter)
+		if (!$this->arbiter)
 			throw new \Exception('Job has no arbiter associated.');
-		
-		if(!$this->script)
+
+		if (!$this->script)
 			throw new \Exception('Job has no script associated.');
-		
+
 		$script = collect($this->script)->toArray();
 		$script['arguments'] = GridService::serializeArray($this->script->arguments);
-		
-		return $this->arbiter->soapCall('OpenJobEx', array([
-			'job' => collect($this)->only(['id', 'expirationInSeconds', 'cores', 'category'])->toArray(),
-			'script' => $script
-		]));
+
+		return $this->arbiter->soapCall('OpenJobEx', array(
+			[
+				'job' => collect($this)->only(['id', 'expirationInSeconds', 'cores', 'category'])->toArray(),
+				'script' => $script
+			]
+		)
+		);
 	}
-	
+
 	public function batch(): array
 	{
-		if(!$this->arbiter)
+		if (!$this->arbiter)
 			throw new \Exception('Job has no arbiter associated.');
-		
-		if(!$this->script)
+
+		if (!$this->script)
 			throw new \Exception('Job has no script associated.');
-		
+
 		$script = collect($this->script)->toArray();
 		$script['arguments'] = GridService::serializeArray($this->script->arguments);
-		
-		return $this->arbiter->soapCall('BatchJobEx', array([
-			'job' => collect($this)->only(['id', 'expirationInSeconds', 'cores', 'category'])->toArray(),
-			'script' => $script
-		]));
+
+		return $this->arbiter->soapCall('BatchJobEx', array(
+			[
+				'job' => collect($this)->only(['id', 'expirationInSeconds', 'cores', 'category'])->toArray(),
+				'script' => $script
+			]
+		)
+		);
 	}
-	
+
 	public function execute(LuaScript $input): array
 	{
-		if(!$this->arbiter)
+		if (!$this->arbiter)
 			throw new \Exception('Job has no arbiter associated.');
-		
+
 		$script = collect($input)->toArray();
 		$script['arguments'] = GridService::serializeArray($input->arguments);
-		
-		return $this->arbiter->soapCall('ExecuteEx', array([
-			'jobID' => $this->id,
-			'script' => $script
-		]));
+
+		return $this->arbiter->soapCall('ExecuteEx', array(
+			[
+				'jobID' => $this->id,
+				'script' => $script
+			]
+		)
+		);
 	}
-	
+
 	public function renewLease(int $expiration): array
 	{
-		if(!$this->arbiter)
+		if (!$this->arbiter)
 			throw new \Exception('Job has no arbiter associated.');
-		
-		return $this->arbiter->soapCall('RenewLease', array([
-			'jobID' => $this->id,
-			'expirationInSeconds' => $expiration
-		]));
+
+		return $this->arbiter->soapCall('RenewLease', array(
+			[
+				'jobID' => $this->id,
+				'expirationInSeconds' => $expiration
+			]
+		)
+		);
 	}
-	
+
 	public function closeJob(): array
 	{
-		if(!$this->arbiter)
+		if (!$this->arbiter)
 			throw new \Exception('Job has no arbiter associated.');
-		
-		return $this->arbiter->soapCall('CloseJob', array([
-			'jobID' => $this->id
-		]));
+
+		return $this->arbiter->soapCall('CloseJob', array(
+			[
+				'jobID' => $this->id
+			]
+		)
+		);
 	}
+	public function getAllJobs(): array
+	{
+		if (!$this->arbiter)
+			throw new \Exception('Job has no arbiter associated.');
+
+		return $this->arbiter->soapCall('GetAllJobs');
+	}
+	
 }


### PR DESCRIPTION
- Corrected formatting in Virtubrick\Grid\Rcc\Job
- Added GetAllJobs (typo in commit message its NOT OpenJobs) from WSDL to receive respect information about running Jobs.

![image](https://github.com/RBXC/virtubrick-grid/assets/77483822/9c11f4b8-b9d6-4a6c-8d1c-033a087b9ac7)
